### PR TITLE
Refatoração de saveState (contato)

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,18 @@
+const { writeFileSync } = require('fs')
+
+const saveContactStateFactory = (config) => {
+    return (id, data) => {
+        const sessionDir =
+            config.storage + '/contacts/' + id.split('@')[0] + '.json'
+
+        if (data) {
+            return writeFileSync(sessionDir, JSON.stringify(data))
+        } else {
+            return false
+        }
+    }
+}
+
+module.exports = {
+    saveContactStateFactory,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-kore-whatsappbot",
-    "version": "0.2.30",
+    "version": "0.2.31",
     "description": "Baileys Whatsapp Multi-Device Bot implementation for Node-Red",
     "main": "index.js",
     "homepage": "https://github.com/riccefarias/node-red-contrib-kore-whatsappbot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-kore-whatsappbot",
-    "version": "0.2.31",
+    "version": "0.2.32",
     "description": "Baileys Whatsapp Multi-Device Bot implementation for Node-Red",
     "main": "index.js",
     "homepage": "https://github.com/riccefarias/node-red-contrib-kore-whatsappbot",
@@ -24,7 +24,8 @@
             "whatsapp-sendImage": "whatsapp-sendImage.js",
             "whatsapp-sendButtons": "whatsapp-sendButtons.js",
             "whatsapp-storeMessage": "whatsapp-storeMessage.js",
-            "whatsapp-addTag": "whatsapp-addTag.js"
+            "whatsapp-addTag": "whatsapp-addTag.js",
+            "whatsapp-endChat": "whatsapp-endChat.js"
         }
     },
     "author": "Angelo Farias <https://github.com/riccefarias>",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "bot"
     ],
     "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
     },
     "node-red": {
         "version": ">=1.3.0",

--- a/whatsapp-addTag.js
+++ b/whatsapp-addTag.js
@@ -1,6 +1,5 @@
 module.exports = function (RED) {
     'use strict'
-    const { writeFileSync } = require('fs')
 
     function WhatsappAddTag(config) {
         RED.nodes.createNode(this, config)

--- a/whatsapp-addTag.js
+++ b/whatsapp-addTag.js
@@ -13,17 +13,6 @@ module.exports = function (RED) {
 
         const clientNode = RED.nodes.getNode(config.client)
 
-        function saveState(id, data) {
-            const sessionDir =
-                clientNode.storage + '/contacts/' + id.split('@')[0] + '.json'
-
-            if (data) {
-                return writeFileSync(sessionDir, JSON.stringify(data))
-            } else {
-                return false
-            }
-        }
-
         if (clientNode) {
             console.log(clientNode)
         }

--- a/whatsapp-client.js
+++ b/whatsapp-client.js
@@ -2,15 +2,13 @@ module.exports = function (RED) {
     'use strict'
     const { unlinkSync, existsSync, mkdirSync } = require('fs')
     const makeWASocket = require('@adiwajshing/baileys')
-    const { WASocket, useSingleFileAuthState } = makeWASocket
+    const { useSingleFileAuthState } = makeWASocket
     const QR = require('qrcode-base64')
     const P = require('pino')
 
     // Imports the Google Cloud client library
     const textToSpeech = require('@google-cloud/text-to-speech')
     const ttsclient = new textToSpeech.TextToSpeechClient()
-
-    const noop = () => {}
 
     let client
 

--- a/whatsapp-endChat.html
+++ b/whatsapp-endChat.html
@@ -1,0 +1,36 @@
+<script type="text/javascript">
+    RED.nodes.registerType('whatsapp-endchat', {
+        category: 'Whatsapp Bot',
+        color: '#c4cc9e',
+        defaults: {
+            client: {
+                type: 'whatsapp-kore-client',
+                required: true,
+            }
+        },
+        inputs: 1,
+        outputs: 1,
+        align: 'left',
+        icon: 'font-awesome/fa-times',
+        paletteLabel: 'Finalizar conversa',
+        label: function () {
+            return 'Finalizar conversa'
+        },
+        outputLabels: function (index) {
+            return index === 0 ? 'Após Gravar' : 'Fluxo'
+        },
+    })
+</script>
+
+<script type="text/html" data-template-name="whatsapp-endchat">
+    <div class="form-row">
+        <label for="node-input-client"
+            ><i class="icon-globe"></i> <span> Cliente WhatsApp</span></label
+        >
+        <input type="text" id="node-input-client" />
+    </div>
+</script>
+
+<script type="text/html" data-help-name="whatsapp-endchat">
+    <p>Reset last node, ending chat and returning contact to initial position</p>
+</script>

--- a/whatsapp-endChat.js
+++ b/whatsapp-endChat.js
@@ -1,0 +1,31 @@
+const { saveContactStateFactory } = require('./helpers')
+
+module.exports = function (RED) {
+    'use strict'
+   
+    function WhatsappEndChat(config) {
+        RED.nodes.createNode(this, config)
+
+        const node = this
+
+        const clientNode = RED.nodes.getNode(config.client)
+
+        const saveContactState = saveContactStateFactory(clientNode)
+
+        if (clientNode) {
+            console.log(clientNode)
+        }
+
+        node.on('input', function (msg) {
+            const to = msg.to || msg.payload.contactId || node.to
+            if (!msg.session) {
+                msg.session = {}
+            } else {
+                delete msg.session['lastNodeId']
+            }
+            saveContactState(to.split('@')[0], msg.session)
+        })
+    }
+
+    RED.nodes.registerType('whatsapp-endchat', WhatsappEndChat)
+}

--- a/whatsapp-sendButtons.js
+++ b/whatsapp-sendButtons.js
@@ -1,6 +1,7 @@
+const { saveContactStateFactory } = require('./helpers')
+
 module.exports = function (RED) {
     'use strict'
-    const { writeFileSync } = require('fs')
 
     function WhatsappSendButtons(config) {
         RED.nodes.createNode(this, config)
@@ -13,16 +14,7 @@ module.exports = function (RED) {
 
         const clientNode = RED.nodes.getNode(config.client)
 
-        function saveState(id, data) {
-            const sessionDir =
-                clientNode.storage + '/contacts/' + id.split('@')[0] + '.json'
-
-            if (data) {
-                return writeFileSync(sessionDir, JSON.stringify(data))
-            } else {
-                return false
-            }
-        }
+        const saveContactState = saveContactStateFactory(clientNode)
 
         if (clientNode) {
             console.log(clientNode)
@@ -39,7 +31,7 @@ module.exports = function (RED) {
 
                 msg.session['lastNodeId'] = node.id
 
-                saveState(to.split('@')[0], msg.session)
+                saveContactState(to.split('@')[0], msg.session)
             }
 
             if (msg.topic === 'buttonResponseMessage') {

--- a/whatsapp-sendImage.js
+++ b/whatsapp-sendImage.js
@@ -1,6 +1,7 @@
+const { saveContactStateFactory } = require('./helpers')
+
 module.exports = function (RED) {
     'use strict'
-    const { writeFileSync } = require('fs')
 
     function WhatsappSendImage(config) {
         RED.nodes.createNode(this, config)
@@ -24,16 +25,7 @@ module.exports = function (RED) {
             })
         }
 
-        function saveState(id, data) {
-            const sessionDir =
-                clientNode.storage + '/contacts/' + id.split('@')[0] + '.json'
-
-            if (data) {
-                return writeFileSync(sessionDir, JSON.stringify(data))
-            } else {
-                return false
-            }
-        }
+        const saveContactState = saveContactStateFactory(clientNode)
 
         if (clientNode) {
             console.log(clientNode)
@@ -54,7 +46,7 @@ module.exports = function (RED) {
                 }
 
                 msg.session['lastNodeId'] = node.id
-                saveState(to.split('@')[0], msg.session)
+                saveContactState(to.split('@')[0], msg.session)
             }
 
             if (

--- a/whatsapp-sendMessage.js
+++ b/whatsapp-sendMessage.js
@@ -1,6 +1,7 @@
+const { saveContactStateFactory } = require('./helpers')
+
 module.exports = function (RED) {
     'use strict'
-    const { writeFileSync } = require('fs')
 
     function WhatsappSendMessage(config) {
         RED.nodes.createNode(this, config)
@@ -23,16 +24,7 @@ module.exports = function (RED) {
             })
         }
 
-        function saveState(id, data) {
-            const sessionDir =
-                clientNode.storage + '/contacts/' + id.split('@')[0] + '.json'
-
-            if (data) {
-                return writeFileSync(sessionDir, JSON.stringify(data))
-            } else {
-                return false
-            }
-        }
+        const saveContactState = saveContactStateFactory(clientNode)
 
         if (clientNode) {
             console.log(clientNode)
@@ -52,7 +44,7 @@ module.exports = function (RED) {
                 }
 
                 msg.session['lastNodeId'] = node.id
-                saveState(to.split('@')[0], msg.session)
+                saveContactState(to.split('@')[0], msg.session)
             }
 
             if (

--- a/whatsapp-storeMessage.js
+++ b/whatsapp-storeMessage.js
@@ -1,6 +1,7 @@
+const { saveContactStateFactory } = require('./helpers')
+
 module.exports = function (RED) {
     'use strict'
-    const { writeFileSync } = require('fs')
 
     function WhatsappStoreMessage(config) {
         RED.nodes.createNode(this, config)
@@ -11,16 +12,7 @@ module.exports = function (RED) {
 
         const clientNode = RED.nodes.getNode(config.client)
 
-        function saveState(id, data) {
-            const sessionDir =
-                clientNode.storage + '/contacts/' + id.split('@')[0] + '.json'
-
-            if (data) {
-                return writeFileSync(sessionDir, JSON.stringify(data))
-            } else {
-                return false
-            }
-        }
+        const saveContactState = saveContactStateFactory(clientNode)
 
         if (clientNode) {
             console.log(clientNode)
@@ -36,7 +28,7 @@ module.exports = function (RED) {
 
                 msg.session['lastNodeId'] = node.id
 
-                saveState(to.split('@')[0], msg.session)
+                saveContactState(to.split('@')[0], msg.session)
             } else if (
                 msg.session === false ||
                 msg.session.lastNodeId === node.id
@@ -50,7 +42,7 @@ module.exports = function (RED) {
                     msg.session['lastNodeId'] = node.id
                     msg.session['user.' + chave] = msg.payload.text
 
-                    saveState(to.split('@')[0], msg.session)
+                    saveContactState(to.split('@')[0], msg.session)
 
                     node.send(msg)
                 } else {


### PR DESCRIPTION
Para evitar repetição (princípio DRY), foi centralizada a função de salvamento do estado do contato (saveState) num módulo a parte (helpers.js).

Também foi mudado o nome de saveState para saveContactState para evitar confusão com o saveState do Whatsapp Baileys.

Adicionada também um node para Finalizar a Conversa, retirando o LastNodeId do estado do contato.